### PR TITLE
Speed up model by improving compute_habit()

### DIFF
--- a/test/time.py
+++ b/test/time.py
@@ -1,0 +1,24 @@
+from timeit import timeit
+
+setup = """
+from vou.person import Person
+from vou.simulation import Simulation
+from vou.visualize import visualize
+from random import Random, randint
+"""
+
+stmt = """
+seed = randint(1, 1e10)
+person = Person(rng=Random(seed))
+
+simulation = Simulation(person=person, rng=Random(seed))
+simulation.simulate()
+
+fig = visualize(person)
+"""
+
+N = 20
+
+time = timeit(stmt, setup, number=N) / N
+
+print(f"Average time per run: {time}")

--- a/vou/person.py
+++ b/vou/person.py
@@ -1,5 +1,7 @@
 from random import Random
 from enum import IntEnum, unique
+from itertools import repeat
+from collections import deque
 
 import numpy as np
 
@@ -44,6 +46,8 @@ class Person:
 
         # A bunch of empty lists to store data during simulation
         self.concentration = []
+        self.tolerance_input = deque(repeat(0, self.tolerance_window))
+        self.tolerance_input_sum = 0
         self.desperation = []
         self.habit = []
         self.effect = []

--- a/vou/simulation.py
+++ b/vou/simulation.py
@@ -359,3 +359,11 @@ class Simulation:
             ),
             0,
         )
+
+
+if __name__ == "__main__":
+    person = Person(rng=Random(1),)
+
+    simulation = Simulation(person=person, rng=Random())
+    simulation.simulate()
+


### PR DESCRIPTION
After profiling the model, `compute_habit()` was the most prominent bottleneck. 

By keeping a separate `deque` of concentration values that influence habit and its running sum, we avoid the two most prominent bottlenecks:
- slicing the list of concentration values to get the last N elements (where N=person.tolerance_window)
- summing the last N concentration values to get the rolling mean of concentration

These improvements reduced average runtime from 4.7 to 0.6 seconds!