### PR TITLE
Incorporate beta test feedback and prepare for counterfeit pills analysis

### DIFF
--- a/notebooks/od_risk_curve.ipynb
+++ b/notebooks/od_risk_curve.ipynb
@@ -1,30 +1,4 @@
 {
- "metadata": {
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.5-final"
-  },
-  "orig_nbformat": 2,
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.8.5 64-bit ('vou': conda)",
-   "metadata": {
-    "interpreter": {
-     "hash": "a4dc872030a726c49c839971b94840ce82689042740c5b089f3174d89e813f92"
-    }
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2,
  "cells": [
   {
    "cell_type": "code",
@@ -45,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dasgupta = pd.read_csv('vou/vou/inputs/dasgupta2016_OD_rates.csv')"
+    "dasgupta = pd.read_csv('inputs/dasgupta2016_OD_rates.csv')"
    ]
   },
   {
@@ -183,11 +157,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Can't find a good fit with a logistic model. Let's try linear."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -231,11 +205,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Polynomial term doesn't seem to be doing much, let's try a simple linear model."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -324,6 +298,10 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Logistic coefficients:\n",
     "# L = 1\n",
@@ -331,11 +309,7 @@
     "# x0 = 1243.6936832876\n",
     "# k = 0.0143710866\n",
     "# y = L / (1 + np.exp(-k * (x - x0))) + b"
-   ],
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
@@ -344,5 +318,29 @@
    "outputs": [],
    "source": []
   }
- ]
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "16482071a8b8e832bb3e8cfed7d9be2ab19135e65a247b1983811020df422475"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.8.5 64-bit ('vou': conda)",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "orig_nbformat": 2
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -8,12 +8,12 @@ from random import Random
 import streamlit as st
 
 
-@st.cache
+# @st.cache
 def simulate(
     rng: Random,
     starting_dose: int = 50,
     dose_increase: int = 25,
-    base_threshold: float = 0.0001,
+    base_threshold: float = 0.001,
     tolerance_window: int = 3_000,
     external_risk: float = 0.5,
     internal_risk: float = 0.5,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,7 @@
 from vou.person import Person, BehaviorWhenResumingUse
 from vou.simulation import Simulation
 from vou.visualize import visualize
+from vou.opioid import mme_equivalents
 
 from random import Random
 
@@ -23,6 +24,7 @@ def simulate(
     dose_variability: float = 0.1,
     availability: float = 0.9,
     fentanyl_prob: float = 0.0001,
+    opioid: str = "Hydrocodone",
 ):
     """
     Streamlit cached function to instantiate a Person and Simulation and run the
@@ -30,10 +32,12 @@ def simulate(
     Streamlit caching and avoid running the simulation repeatedly when an app user
     changes visualization parameters.
     """
+    dose_multiplier = mme_equivalents[opioid]
+
     person = Person(
         rng=rng,
-        starting_dose=starting_dose,
-        dose_increase=dose_increase,
+        starting_dose=starting_dose * dose_multiplier,
+        dose_increase=dose_increase * dose_multiplier,
         base_threshold=base_threshold,
         tolerance_window=tolerance_window,
         external_risk=external_risk,
@@ -113,13 +117,31 @@ if __name__ == "__main__":
             )
         sim_params = st.expander("Simulation Parameters")
         with sim_params:
+            opioid = st.selectbox(
+                label="Select the opioid prescribed to the user",
+                help="The user takes one opioid type throughout the simulation. They can increase their dose over time, but always continue to take the same opioid. The chosen opioid/dose combination is converted to morphine milligram equivalents within the simulation.",
+                options=[
+                    "Codeine",
+                    "Dihydrocodeine",
+                    "Hydrocodone",
+                    "Hydromorphone",
+                    "Levorphanol Tartrate",
+                    "Meperidine Hcl",
+                    "Oxycodone",
+                    "Oxymorphone",
+                    "Pentazocine",
+                    "Tapentadol",
+                    "Tramadol",
+                ],
+                index=0,
+            )
             starting_dose = st.slider(
                 label="Select the user's starting dose in MME",
                 help="The user starts the simulation taking their preferred dose consistently. This parameter controls their preferred dose at the start of the simulation.",
-                min_value=10,
+                min_value=5,
                 max_value=200,
                 value=50,
-                step=10,
+                step=5,
             )
             dose_increase = st.slider(
                 label="Select the amount the user will add when increasing dose",
@@ -206,6 +228,7 @@ if __name__ == "__main__":
         dose_variability=dose_variability,
         availability=availability,
         fentanyl_prob=fentanyl_prob,
+        opioid=opioid,
     )
 
     with col1:
@@ -254,6 +277,7 @@ if __name__ == "__main__":
             show_desperation=show_desperation,
             show_habit=show_habit,
             show_effect=show_effect,
+            opioid=opioid,
         )
         st.pyplot(fig, dpi=300)
         if show_zoomed_viz is True:
@@ -264,6 +288,7 @@ if __name__ == "__main__":
                 show_desperation=show_desperation,
                 show_habit=show_habit,
                 show_effect=show_effect,
+                opioid=opioid,
             )
             st.pyplot(zoomed_fig, dpi=300)
         st.markdown(

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -136,7 +136,7 @@ if __name__ == "__main__":
                     "Tapentadol",
                     "Tramadol",
                 ],
-                index=0,
+                index=2,
             )
             starting_dose = st.slider(
                 label="Select the user's starting dose in MME",

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -24,6 +24,7 @@ def simulate(
     dose_variability: float = 0.1,
     availability: float = 0.9,
     fentanyl_prob: float = 0.0001,
+    counterfeit_prob: float = 0.1,
     opioid: str = "Hydrocodone",
 ):
     """
@@ -53,6 +54,7 @@ def simulate(
         dose_variability=dose_variability,
         availability=availability,
         fentanyl_prob=fentanyl_prob,
+        counterfeit_prob=counterfeit_prob,
     )
     simulation.simulate()
     return person
@@ -151,14 +153,6 @@ if __name__ == "__main__":
                 value=25,
                 step=5,
             )
-            dose_variability = st.slider(
-                label="Select the variability of dosage",
-                help="Due to variability in supply and dose measurement, the user's doses may fluctuate from their preferred dose. This parameter controls the proportion by which doses will fluctuate relative to the user's preferred dose.",
-                min_value=0.0,
-                max_value=0.5,
-                value=0.1,
-                step=0.05,
-            )
             availability = st.slider(
                 label="Select probability that opioids will be available per day",
                 help="For various reasons (e.g. supply, ability to pay), the user may not always be able to get opioids when they want to. The model updates opioid availability each day. This parameter controls the probability that opioids will be available each day.",
@@ -167,13 +161,29 @@ if __name__ == "__main__":
                 value=0.75,
                 step=0.05,
             )
-            fentanyl_prob = st.slider(
-                label="Select probability of fentanyl adulteration per dose",
-                help="In addition to regular variability of dose, some opioid batches may be far more potent than expected due to adulteration with powerful synthetic opioids like fentanyl. This parameter controls the probability that a given dose will be adulterated with a synthetic opioid.",
+            counterfeit_prob = st.slider(
+                label="Select probability that each dose will be a counterfeit pill",
+                help="Illicit opioid pills are often counterfeit. Counterfeit pills vary in purity and dose. This parameter controls the probability that each dose will be counterfeit, leading to greater variability.",
                 min_value=0.0,
-                max_value=0.05,
-                value=0.001,
-                step=0.001,
+                max_value=0.5,
+                value=0.1,
+                step=0.05,
+            )
+            dose_variability = st.slider(
+                label="Select the variability of dosage in counterfeit pills",
+                help="Due to variability in supply and dose measurement, the user's doses may fluctuate from their preferred dose. This parameter controls the proportion by which doses will fluctuate relative to the user's preferred dose.",
+                min_value=0.1,
+                max_value=0.5,
+                value=0.2,
+                step=0.05,
+            )
+            fentanyl_prob = st.slider(
+                label="Select probability that a counterfeit pill is adulterated with fentanyl",
+                help="In addition to regular variability of dose, some counterfeits may be far more potent than expected due to adulteration with powerful synthetic opioids like fentanyl. This parameter controls the probability that a counterfeit dose will be adulterated with a synthetic opioid.",
+                min_value=0.0,
+                max_value=0.5,
+                value=0.01,
+                step=0.01,
             )
             use_mode = st.selectbox(
                 label="Select user behavior pattern",
@@ -228,6 +238,7 @@ if __name__ == "__main__":
         dose_variability=dose_variability,
         availability=availability,
         fentanyl_prob=fentanyl_prob,
+        counterfeit_prob=counterfeit_prob,
         opioid=opioid,
     )
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -129,6 +129,7 @@ if __name__ == "__main__":
                     "Hydromorphone",
                     "Levorphanol Tartrate",
                     "Meperidine Hcl",
+                    "Morphine",
                     "Oxycodone",
                     "Oxymorphone",
                     "Pentazocine",
@@ -166,15 +167,15 @@ if __name__ == "__main__":
                 help="Illicit opioid pills are often counterfeit. Counterfeit pills vary in purity and dose. This parameter controls the probability that each dose will be counterfeit, leading to greater variability.",
                 min_value=0.0,
                 max_value=0.5,
-                value=0.1,
+                value=0.25,
                 step=0.05,
             )
             dose_variability = st.slider(
                 label="Select the variability of dosage in counterfeit pills",
                 help="Due to variability in supply and dose measurement, the user's doses may fluctuate from their preferred dose. This parameter controls the proportion by which doses will fluctuate relative to the user's preferred dose.",
                 min_value=0.1,
-                max_value=0.5,
-                value=0.2,
+                max_value=0.75,
+                value=0.5,
                 step=0.05,
             )
             fentanyl_prob = st.slider(
@@ -182,8 +183,8 @@ if __name__ == "__main__":
                 help="In addition to regular variability of dose, some counterfeits may be far more potent than expected due to adulteration with powerful synthetic opioids like fentanyl. This parameter controls the probability that a counterfeit dose will be adulterated with a synthetic opioid.",
                 min_value=0.0,
                 max_value=0.5,
-                value=0.01,
-                step=0.01,
+                value=0.25,
+                step=0.05,
             )
             use_mode = st.selectbox(
                 label="Select user behavior pattern",

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -22,6 +22,7 @@ def simulate(
     stop_use_day: int = None,
     resume_use_day: int = None,
     dose_variability: float = 0.1,
+    behavioral_variability: float = 0.1,
     availability: float = 0.9,
     fentanyl_prob: float = 0.0001,
     counterfeit_prob: float = 0.1,
@@ -43,6 +44,7 @@ def simulate(
         tolerance_window=tolerance_window,
         external_risk=external_risk,
         internal_risk=internal_risk,
+        behavioral_variability=behavioral_variability,
         behavior_when_resuming_use=behavior_when_resuming_use,
     )
     simulation = Simulation(
@@ -115,6 +117,14 @@ if __name__ == "__main__":
                 min_value=0.05,
                 max_value=1.0,
                 value=0.5,
+                step=0.05,
+            )
+            behavioral_variability = st.slider(
+                label="Select the proportion by whcih the user varies their dose from day to day",
+                help="The user always has a preferred dose. If this parameter is 0, they always take that exact dose. If this parameter is 1, they vary their dose by up to 1x their preferred dose each time.",
+                min_value=0.0,
+                max_value=1.0,
+                value=0.1,
                 step=0.05,
             )
         sim_params = st.expander("Simulation Parameters")
@@ -238,6 +248,7 @@ if __name__ == "__main__":
         resume_use_day=resume_use_day,
         dose_variability=dose_variability,
         availability=availability,
+        behavioral_variability=behavioral_variability,
         fentanyl_prob=fentanyl_prob,
         counterfeit_prob=counterfeit_prob,
         opioid=opioid,

--- a/vou/opioid.py
+++ b/vou/opioid.py
@@ -1,0 +1,13 @@
+mme_equivalents = {
+    "Codeine": 0.15,
+    "Dihydrocodeine": 0.25,
+    "Hydrocodone": 1,
+    "Hydromorphone": 4,
+    "Levorphanol Tartrate": 11,
+    "Meperidine Hcl": 0.1,
+    "Oxycodone": 1.5,
+    "Oxymorphone": 3,
+    "Pentazocine": 0.37,
+    "Tapentadol": 0.4,
+    "Tramadol": 0.1,
+}

--- a/vou/opioid.py
+++ b/vou/opioid.py
@@ -5,6 +5,7 @@ mme_equivalents = {
     "Hydromorphone": 4,
     "Levorphanol Tartrate": 11,
     "Meperidine Hcl": 0.1,
+    "Morphine": 1,
     "Oxycodone": 1.5,
     "Oxymorphone": 3,
     "Pentazocine": 0.37,

--- a/vou/person.py
+++ b/vou/person.py
@@ -1,3 +1,5 @@
+from vou.utils import logistic
+
 from random import Random
 from enum import IntEnum, unique
 from itertools import repeat
@@ -125,6 +127,42 @@ class Person:
         elif self.rng.random() < self.downward_pressure:
             return False
         else:
+            return True
+
+    def did_overdose(self, x0: float = 1243.6936832876, k: float = 0.0143710866):
+        """
+        Checks whether the person's most recent opioid dose causes an overdose.
+
+        First, a baseline OD risk value is generated using a function derived from
+        Dasgupta et al 2016. A logistic model was fitted to their data, along with 
+        the assumption that a dose of 2 grams has an OD probability of 1. (See
+        notebooks/od_risk_curve.ipynb). We use that model to generate the baseline
+        risk value for the person's dose.
+
+        Since the Dasgupta study used prescription data, we assume that these overdose
+        risks are for people who are tolerant to their prescribed dose. Therefore,
+        we add an additional risk multiplier based on the ratio of the dose to the
+        person's tolerance.
+
+        A very general heuristic is that at steady state, (preferred_dose / tolerance)
+        roughly equals 2. We define "excess" as (dose / tolerance) - 1, or roughly 1 at
+        steady state. We multiply the person's baseline OD risk by this excess squared.
+        """
+        dose = self.concentration[-1]
+        tolerance = self.habit[-1]
+
+        # bound extremely low tolerance values to avoid huge excess values
+        tolerance = max(1, tolerance)
+
+        # parameters based on Dasgupta et al 2016 - see notebooks/od_risk_curve.ipynb
+        baseline_OD_risk = logistic(x=dose, L=1, k=k, x0=x0)
+
+        excess = ((dose / tolerance) - 1) ** 2
+
+        tolerance_adjusted_OD_risk = baseline_OD_risk * excess
+
+        if self.rng.random() < tolerance_adjusted_OD_risk:
+            # Overdose occurred
             return True
 
     def overdose(self, t: int):

--- a/vou/person.py
+++ b/vou/person.py
@@ -30,6 +30,7 @@ class Person:
         tolerance_window: int = 3_000,
         external_risk: float = 0.5,
         internal_risk: float = 0.5,
+        behavioral_variability: float = 0.1,
         behavior_when_resuming_use: BehaviorWhenResumingUse = None,
     ):
         # Parameters
@@ -40,6 +41,7 @@ class Person:
         self.tolerance_window = tolerance_window
         self.external_risk = external_risk
         self.internal_risk = internal_risk
+        self.behavioral_variability = behavioral_variability
         self.update_downward_pressure()
         self.set_risk_logit()
         self.behavior_when_resuming_use = behavior_when_resuming_use

--- a/vou/simulation.py
+++ b/vou/simulation.py
@@ -76,7 +76,8 @@ class Simulation:
 
             # Check if the person will take another dose
             if self.opioid_available is True:
-                if self.person.will_take_dose(t) is True:
+                # if self.person.will_take_dose(t) is True:
+                if self.person.will_take_dose(t) is True or t % 100 == 0:
                     self.record_dose_taken(t)
 
             # Compute the person's opioid use habit at t
@@ -127,24 +128,25 @@ class Simulation:
         Therefore, in our case:
 
         k = ln(2) / 11.667 = 0.0594
-
-
         """
         return (self.conc_when_dose_taken + self.last_amount_taken) * math.exp(
             -k * self.time_since_dose
         )
 
     def compute_effect(
-        self, A: float = 0.25,
+        self, k: float = 0.0594,
     ):
         """
         Computes opioid's effect on the the person at a time step, given their
         concentration of opioid and opioid use habit.
-        A is a calibrated parameter.
+        
+        k is a calibrated parameter. See docstring for compute_concentration for details.
         """
-        return (
-            self.conc_when_dose_taken + self.last_amount_taken - self.person.habit[-1]
-        ) * math.exp(-A * self.time_since_dose)
+        return max(
+            (self.conc_when_dose_taken + self.last_amount_taken - self.person.habit[-1])
+            * math.exp(-k * self.time_since_dose),
+            0,
+        )
 
     def update_availability(self, t: int):
         """
@@ -251,8 +253,8 @@ class Simulation:
     def compute_habit(
         self,
         t: int,
-        conc_multiplier: int = 3,
-        L1: float = 1.02,
+        conc_multiplier: int = 1.85,
+        L1: float = 1.0275,
         L2: float = 0.58,
         K1: float = 0.2,
         K2: float = 0.0002,

--- a/vou/simulation.py
+++ b/vou/simulation.py
@@ -215,24 +215,32 @@ class Simulation:
         """
         Computes the amount of opioid taken in MME when the person takes a dose.
 
-        First, checks whether the dose consists of counterfeit pills. If not, the dose
+        First, checks whether the user decides to vary their dose. 
+        
+        Next, check whether the dose consists of counterfeit pills. If not, the dose
         taken is the user's preferred dose exactly. If so, the dose taken is modified
         by several multipliers.
 
-        1. The dose variability parameter represents general variation in the purity
+        1. The person's behavioral variability parameter represents variation in the dose
+        the person intends to take relative to their usual preferred dose.
+        
+        2. The dose variability parameter represents general variation in the purity
         and consistency of counterfeit pills.
 
-        2. The fentanyl probabiltiy parameter represents the likelihood that a
+        3. The fentanyl probabiltiy parameter represents the likelihood that a
         counterfeit pill is part of a "bad batch" contaminated with fentanyl. 
         If so, the modified dose is multiplied by a random value:
         1 + a random draw from an exponential distribution with mean 0.25 (the 
         lambd parameter in random.expovariate is 1 divided by the mean).
         """
-        modified_dose = copy(self.person.dose)
+        modified_dose = self.person.dose * self.rng.uniform(
+            1 - self.person.behavioral_variability,
+            1 + self.person.behavioral_variability,
+        )
 
         if self.rng.random() < self.counterfeit_prob:
 
-            modified_dose = self.person.dose * self.rng.uniform(
+            modified_dose = modified_dose * self.rng.uniform(
                 1 - self.dose_variability, 1 + self.dose_variability
             )
             if self.rng.random() < self.fentanyl_prob:
@@ -328,7 +336,7 @@ class Simulation:
         self.integralD.append(ALPHA4 * self.integralD[-1] + self.integralC[-1] / BETA4)
 
     def compute_threshold(
-        self, B1=0.05, B2=0.1, B3=0.5,
+        self, B1=0.001, B2=0.01, B3=0.5,
     ):
         """
         Computes the person's threshold to take another dose for the next time step.

--- a/vou/simulation.py
+++ b/vou/simulation.py
@@ -89,7 +89,7 @@ class Simulation:
             # each time the person takes a dose.
             if self.dose_taken_at_t is True:
                 # Check for overdose.
-                if self.did_person_overdose() is True:
+                if self.person.did_overdose() is True:
                     overdose = self.person.overdose(t)
                     if overdose == OverdoseType.FATAL:
                         break
@@ -282,28 +282,6 @@ class Simulation:
             k=K1 - (self.person.dose * K2),
             x0=self.person.dose * X1,
         )
-
-    def did_person_overdose(self):
-        """
-        Checks whether the most recent opioid effect on the person causes an overdose.
-
-        Based on a random draw and a simple, discrete set of OD probabilities at various
-        effect levels.
-        """
-        effect = self.person.effect[-1]
-
-        if effect > 650:
-            od_prob = 0.5
-        elif effect > 500:
-            od_prob = 0.25
-        elif effect > 350:
-            od_prob = 0.1
-        else:
-            od_prob = 0
-
-        if self.rng.random() < od_prob:
-            # Overdose occurred
-            return True
 
     def compute_concentration_integrals(
         self,

--- a/vou/simulation.py
+++ b/vou/simulation.py
@@ -110,14 +110,28 @@ class Simulation:
             self.person.threshold = self.compute_threshold()
 
     def compute_concentration(
-        self, A: float = 0.25,
+        self, k: float = 0.0594,
     ):
         """
         Computes the person's concentration of opioids in MME at a time step.
         A is a calibrated parameter.
+
+        This pharmacokinetic decay function was calibrated to the half life of morphine.
+        Per Lotsch 2005, 3 studies identifed this value as 2.8 hours, which we use here.
+
+        This model uses 100 time steps per day, so each time step equates to
+        24 * 60 / 100 = 14.4 minutes. The half life in model time units is 
+        2.8 * 60 / 14.4 = 11.667 time units.
+
+        For first-order decay functions, the decay constant k = ln(2) / half_life.
+        Therefore, in our case:
+
+        k = ln(2) / 11.667 = 0.0594
+
+
         """
         return (self.conc_when_dose_taken + self.last_amount_taken) * math.exp(
-            -A * self.time_since_dose
+            -k * self.time_since_dose
         )
 
     def compute_effect(
@@ -314,7 +328,7 @@ class Simulation:
         self.integralD.append(ALPHA4 * self.integralD[-1] + self.integralC[-1] / BETA4)
 
     def compute_threshold(
-        self, B1=0.0001, B2=0.01, B3=0.5,
+        self, B1=0.05, B2=0.1, B3=0.5,
     ):
         """
         Computes the person's threshold to take another dose for the next time step.

--- a/vou/visualize.py
+++ b/vou/visualize.py
@@ -88,7 +88,7 @@ def visualize(
             ymin=0,
             ymax=max(person.concentration) / dose_multiplier,
             colors="black",
-            linestyles="dashed",
+            linestyles="dotted",
             label="OD",
             zorder=4,
         )
@@ -105,7 +105,7 @@ def visualize(
             ymin=0,
             ymax=max(person.concentration) / dose_multiplier,
             colors="black",
-            linestyles="dashed",
+            linestyles="dotted",
             label="OD",
             zorder=4,
         )

--- a/vou/visualize.py
+++ b/vou/visualize.py
@@ -1,4 +1,5 @@
 from vou.person import Person
+from vou.opioid import mme_equivalents
 
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
@@ -19,6 +20,7 @@ def visualize(
     show_desperation: bool = False,
     show_habit: bool = True,
     show_effect: bool = True,
+    opioid: str = "Hydrocodone",
 ):
     """
     Generates a plot of the person's opioid concentration, habit, effect,
@@ -28,6 +30,8 @@ def visualize(
 
     Start day and duration parameters allow control over time frame shown.
     """
+    dose_multiplier = mme_equivalents[opioid]
+
     palette = make_ibm_color_palette()
     start_time = 0 if start_day == 0 else start_day * 100
     duration_time = duration * 100
@@ -37,7 +41,8 @@ def visualize(
 
     ax1.plot(
         range(start_time, end_time),
-        person.concentration[start_time:end_time],
+        [c / dose_multiplier for c in person.concentration[start_time:end_time]]
+        + [0] * max(0, (end_time - start_time) - len(person.concentration)),
         label="Concentration",
         color=palette[0],
         zorder=0,
@@ -45,7 +50,8 @@ def visualize(
     if show_habit:
         ax1.plot(
             range(start_time, end_time),
-            person.habit[start_time:end_time],
+            [h / dose_multiplier for h in person.habit[start_time:end_time]]
+            + [0] * max(0, (end_time - start_time) - len(person.habit)),
             label="Tolerance",
             color=palette[1],
             zorder=2,
@@ -53,7 +59,8 @@ def visualize(
     if show_effect:
         ax1.plot(
             range(start_time, end_time),
-            person.effect[start_time:end_time],
+            [e / dose_multiplier for e in person.effect[start_time:end_time]]
+            + [0] * max(0, (end_time - start_time) - len(person.effect)),
             label="Effect",
             color=palette[2],
             zorder=1,
@@ -61,13 +68,14 @@ def visualize(
     if len(person.concentration) < end_time:
         ax1.set_xlim(right=end_time)
 
-    ax1.set_ylabel("Morphine Milligram Equivalents (MME)")
+    ax1.set_ylabel(f"Milligrams of {opioid}")
 
     if show_desperation:
         ax2 = ax1.twinx()
         ax2.plot(
             range(start_time, end_time),
-            person.desperation[start_time:end_time],
+            [d / dose_multiplier for d in person.desperation[start_time:end_time]]
+            + [0] * max(0, (end_time - start_time) - len(person.desperation)),
             label="Desperation",
             color=palette[3],
             zorder=3,
@@ -78,7 +86,7 @@ def visualize(
         ax2.vlines(
             x=[od for od in person.overdoses if start_time <= od < end_time],
             ymin=0,
-            ymax=max(person.concentration),
+            ymax=max(person.concentration) / dose_multiplier,
             colors="black",
             linestyles="dashed",
             label="OD",
@@ -95,7 +103,7 @@ def visualize(
         ax1.vlines(
             x=[od for od in person.overdoses if start_time <= od < end_time],
             ymin=0,
-            ymax=max(person.concentration),
+            ymax=max(person.concentration) / dose_multiplier,
             colors="black",
             linestyles="dashed",
             label="OD",


### PR DESCRIPTION
This PR incorporates changes suggested by Mark Edlund, Paolo Manelli, and Dan Ciccarone during the beta testing process. 

Changes include:
- Adding a dose translation table, so the user specifies dose in terms of a specific opioid, which is then converted to MMEs 
- Add the concept of counterfeit pills and adjust variability mechanisms accordingly
    - Add counterfeit pills slider
    - Dose variability and fentanyl adulteration now affect counterfeit doses only
    - Add behavioral variability to reflect intentional variation of dose as well as variation caused by uncertain concentration of counterfeit pills
- Improve overdose risk calculation
    -  Calculate baseline risk from Dasgupta et al
    - Assume baseline risk is for tolerant users, add risk multiplier when user takes dose above their tolerance
- Calibrate decay function to morphine plasma concentration half life
- Enforce 2 doses per day and calibrate tolerance function to produce desired dose increase behavior given 2-dose paradigm