### PR TITLE
Make habit function params variable

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -25,7 +25,7 @@ def simulate(
     dose_variability: float = 0.1,
     behavioral_variability: float = 0.1,
     availability: float = 0.9,
-    fentanyl_prob: float = 0.0001,
+    bad_batch_prob: float = 0.0001,
     counterfeit_prob: float = 0.1,
     opioid: str = "Hydrocodone",
 ):
@@ -56,7 +56,7 @@ def simulate(
         resume_use_day=resume_use_day,
         dose_variability=dose_variability,
         availability=availability,
-        fentanyl_prob=fentanyl_prob,
+        bad_batch_prob=bad_batch_prob,
         counterfeit_prob=counterfeit_prob,
     )
     simulation.simulate()
@@ -190,7 +190,7 @@ if __name__ == "__main__":
                 value=0.5,
                 step=0.05,
             )
-            fentanyl_prob = st.slider(
+            bad_batch_prob = st.slider(
                 label="Select probability that a counterfeit pill is adulterated with fentanyl",
                 help="In addition to regular variability of dose, some counterfeits may be far more potent than expected due to adulteration with powerful synthetic opioids like fentanyl. This parameter controls the probability that a counterfeit dose will be adulterated with a synthetic opioid.",
                 min_value=0.0,
@@ -252,7 +252,7 @@ if __name__ == "__main__":
         dose_variability=dose_variability,
         availability=availability,
         behavioral_variability=behavioral_variability,
-        fentanyl_prob=fentanyl_prob,
+        bad_batch_prob=bad_batch_prob,
         counterfeit_prob=counterfeit_prob,
         opioid=opioid,
     )

--- a/vou/simulation.py
+++ b/vou/simulation.py
@@ -1,10 +1,20 @@
 import math
 from random import Random
+from typing import TypedDict
 
 import numpy as np
 
 from vou.person import BehaviorWhenResumingUse, DoseIncreaseSource, OverdoseType, Person
 from vou.utils import logistic, weighted_random_by_dct
+
+
+class HabitParams(TypedDict):
+    conc_multiplier: float
+    L1: float
+    L2: float
+    K1: float
+    K2: float
+    X1: float
 
 
 class Simulation:
@@ -21,6 +31,14 @@ class Simulation:
         counterfeit_prob: float = 0.1,
         source_variability: float = 0.2,
         fentanyl_variability: float = 0.1,
+        habit_params: HabitParams = {
+            "conc_multiplier": 1.85,
+            "L1": 1.0275,
+            "L2": 0.58,
+            "K1": 0.2,
+            "K2": 0.0002,
+            "X1": 0.175,
+        },
     ):
         # Parameters
         self.person = person
@@ -34,6 +52,7 @@ class Simulation:
         self.counterfeit_prob = counterfeit_prob
         self.source_variability = source_variability
         self.fentanyl_variability = fentanyl_variability
+        self.habit_params = habit_params
 
         # Variables used in simulation
         self.time_since_dose = 0
@@ -370,12 +389,12 @@ class Simulation:
     def compute_habit(
         self,
         t: int,
-        conc_multiplier: int = 1.85,
-        L1: float = 1.0275,
-        L2: float = 0.58,
-        K1: float = 0.2,
-        K2: float = 0.0002,
-        X1: float = 0.175,
+        # conc_multiplier: int = 1.85,
+        # L1: float = 1.0275,
+        # L2: float = 0.58,
+        # K1: float = 0.2,
+        # K2: float = 0.0002,
+        # X1: float = 0.175,
     ):
         """
         Computes the person's opioid use "habit" at a time point.
@@ -397,7 +416,7 @@ class Simulation:
         # small relative to concentration.
         rolling_concentration = (
             self.person.tolerance_input_sum / self.person.tolerance_window
-        ) * conc_multiplier
+        ) * self.habit_params["conc_multiplier"]
 
         # Compute habit based on a logistic function of the rolling concentration.
         #
@@ -419,9 +438,9 @@ class Simulation:
         # curve at a wide range of doses.
         return logistic(
             x=rolling_concentration,
-            L=(self.person.dose ** L1) * L2,
-            k=K1 - (self.person.dose * K2),
-            x0=self.person.dose * X1,
+            L=(self.person.dose ** self.habit_params["L1"]) * self.habit_params["L2"],
+            k=self.habit_params["K1"] - (self.person.dose * self.habit_params["K2"]),
+            x0=self.person.dose * self.habit_params["X1"],
         )
 
     def compute_concentration_integrals(

--- a/vou/simulation.py
+++ b/vou/simulation.py
@@ -387,14 +387,7 @@ class Simulation:
         return modified_dose
 
     def compute_habit(
-        self,
-        t: int,
-        # conc_multiplier: int = 1.85,
-        # L1: float = 1.0275,
-        # L2: float = 0.58,
-        # K1: float = 0.2,
-        # K2: float = 0.0002,
-        # X1: float = 0.175,
+        self, t: int,
     ):
         """
         Computes the person's opioid use "habit" at a time point.


### PR DESCRIPTION
Adds functionality to pass habit function params at simulation instantiation, rather than using a fixed set of habit params.

The app doesn't take advantage of this functionality yet (although it could). The purpose of this addition is to enable batch simulations which import `vou` to vary habit params in simulation experiments.